### PR TITLE
switch node workflow to use main as branch name

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
   build:


### PR DESCRIPTION
default branch has been renamed from master to main. The nodejs workflow script needs to be updated to match the new default branch name.