### PR TITLE
remove support for Python versions less than 3.10

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -39,5 +39,5 @@ jobs:
         mypy musicbingo
     - name: Lint with pylint
       run: |
-        pip install pylint==2.16.2
+        pip install pylint==2.17.4
         pylint --rcfile=.pylintrc musicbingo

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -3,31 +3,14 @@ name: Python application
 on: [push]
 
 jobs:
-  build36:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.6
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r dev-requirements.txt
-    - name: Test with pytest
-      run: |
-        pip install pytest
-        pytest
-  build39:
+  build310:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ tbd
 * upgraded Flask to v2.2.5
 * replace apscheduler with flask_apscheduler
 
+### Removed
+
+* support for Python versions less than 3.10
+
 ## 0.2.2
 
 May 22 2023

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ It also contains a server that provides an HTML JavsScript application
 that can be run from any web browser. This web app allows multiple people
 to play Music Bingo together on-line.
 
+It requires Python version 3.10 or greater.
+
 ## Application
 
 This repository contains a local GUI application (written in Python and

--- a/musicbingo/docgen/pdfgen.py
+++ b/musicbingo/docgen/pdfgen.py
@@ -6,12 +6,11 @@ It uses the reportlab library to produce the PDF documents.
 import logging
 from typing import (
     Any, Callable, Iterable, List, Mapping, Optional,
-    Tuple, Type, Union, cast,
+    Protocol, Tuple, Type, Union, cast,
 )
 
 from reportlab import platypus, lib  # type: ignore
 from reportlab.pdfgen.canvas import Canvas  # type: ignore
-from typing_extensions import Protocol
 
 from musicbingo.progress import Progress
 from musicbingo.tests.mixin import TestCaseMixin

--- a/musicbingo/docgen/sizes/pagesize.py
+++ b/musicbingo/docgen/sizes/pagesize.py
@@ -3,12 +3,7 @@ Document page sizes
 """
 
 from enum import Enum
-from typing import List, NamedTuple
-
-# Protocol was added in Python 3.8
-# use typing_extensions so that earlier Python versions
-# can be used
-from typing_extensions import Protocol
+from typing import List, NamedTuple, Protocol
 
 from .dimension import Dimension
 

--- a/musicbingo/gui/dialogbase.py
+++ b/musicbingo/gui/dialogbase.py
@@ -5,10 +5,9 @@ This class is based upon the code from:
 http://effbot.org/tkinterbook/tkinter-dialog-windows.htm
 """
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Union
+from typing import Any, Optional, Protocol, Union
 
 import tkinter as tk  # pylint: disable=import-error
-from typing_extensions import Protocol
 
 from .panel import Panel
 

--- a/musicbingo/gui/settingsdialog.py
+++ b/musicbingo/gui/settingsdialog.py
@@ -1,10 +1,11 @@
 """
 Dialog box for selecting one item from a list of items
 """
-from typing import cast, Any, Dict, List, Optional, Set, Union
+from typing import (
+    cast, Any, Dict, List, Optional, Protocol, Set, Union
+)
 
 import tkinter as tk  # pylint: disable=import-error
-from typing_extensions import Protocol
 
 from musicbingo.mp3.factory import MP3Factory
 from musicbingo.options import Options, OptionField

--- a/musicbingo/models/query.py
+++ b/musicbingo/models/query.py
@@ -1,9 +1,7 @@
 """
 Interface definition for a database query
 """
-from typing import Any
-
-from typing_extensions import Protocol
+from typing import Any, Protocol
 
 class DatabaseQuery(Protocol):
     """

--- a/musicbingo/models/session.py
+++ b/musicbingo/models/session.py
@@ -2,10 +2,7 @@
 Interface definition for a database session
 """
 
-# Protocol was added in Python 3.8
-# use typing_extensions so that earlier Python versions
-# can be used
-from typing_extensions import Protocol
+from typing import Protocol
 
 class DatabaseSession(Protocol):
     """

--- a/musicbingo/tests/liveserver.py
+++ b/musicbingo/tests/liveserver.py
@@ -12,15 +12,9 @@ import os
 from platform import python_version_tuple
 import socket
 import time
-from typing import ContextManager
+from typing import ContextManager, Protocol
 import unittest
 from urllib.parse import urlparse
-
-# Protocol was added in Python 3.8
-# use typing_extensions so that earlier Python versions
-# can be used
-from typing_extensions import Protocol
-
 
 class IntValueType(Protocol):
     """

--- a/musicbingo/utils.py
+++ b/musicbingo/utils.py
@@ -8,8 +8,10 @@ import math
 from pathlib import Path
 import re
 import time
-from typing import AbstractSet, Any, Dict, List, Optional, Union
-from typing_extensions import Protocol
+from typing import (
+    AbstractSet, Any, Dict, List, Optional, Protocol,
+    Union
+)
 
 from musicbingo.docgen.colour import Colour
 from musicbingo.docgen.sizes.dimension import Dimension

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,27 +1,21 @@
 apscheduler==3.9.1
-backports.zoneinfo==0.2.1; python_version < '3.10'
 bcrypt==3.2.0
 chardet==3.0.4
 types-chardet==0.1.3
 fastjsonschema==2.16.3
-Flask==2.0.3; python_version <= '3.6'
-Flask==2.2.5; python_version > '3.6'
+Flask==2.2.5
 Flask-APScheduler==1.12.4
 Flask-Cors==3.0.9
-Flask-JWT-Extended==4.4.2; python_version <= '3.6'
-Flask-JWT-Extended==4.4.4; python_version > '3.6'
+Flask-JWT-Extended==4.4.4
 Flask-Login==0.5.0
 mutagen==1.45.1
 passlib==1.7.4
-pillow==8.4.0; python_version <= '3.6'
-pillow==9.3.0; python_version > '3.6'
+pillow==9.3.0
 psutil==5.9.0
 pydub==0.25.1
 pyparsing==2.4.7
 pytz==2020.1
-reportlab==3.6.8; python_version <= '3.6'
-reportlab==3.6.12; python_version > '3.6'
-setuptools==65.5.1; python_version > '3.6'
+reportlab==3.6.12
+setuptools==65.5.1
 SQLAlchemy==1.4.41
 sqlalchemy_jsonfield==0.9.0
-typing-extensions==4.1.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39, py310, py311
+envlist = py310, py311
 skipsdist = True
 skip_missing_interpreters = True
 
@@ -18,15 +18,3 @@ commands =
          python -m unittest discover
          mypy musicbingo
          pylint --rcfile=.pylintrc musicbingo
-
-[testenv:py36]
-deps =
-    -rrequirements.txt
-    -rdev-requirements.txt
-    tk-tools
-    pylint==2.16.2
-    mypy==0.971
-
-commands =
-         python -m unittest discover
-         mypy musicbingo

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     -rrequirements.txt
     -rdev-requirements.txt
     tk-tools
-    pylint
+    pylint==2.17.4
     mypy==0.991
 setenv = MYPYPATH = {toxinidir}/stubs
 


### PR DESCRIPTION
Python 3.10 was released in 2021 and reached its end of full support this month. Therefore it seems reasonable to make this the new minimum Python version to support. Trying to support really old versions such as 3.6 was become too large a burden.