### PR TITLE
add models management command to create clip index files

### DIFF
--- a/musicbingo/directory.py
+++ b/musicbingo/directory.py
@@ -3,7 +3,6 @@ Classes to store directories of mp3 files.
 """
 
 from concurrent import futures
-import csv
 import hashlib
 import json
 import os
@@ -415,22 +414,6 @@ class Directory(HasParent):
             with cfn.open('w') as cache_file:
                 cache_file.write(js_str)
             self.cache_hash = digest
-
-    def create_index(self, filename: str) -> None:
-        """Create a CSV file that contains a list of all songs"""
-        with open(filename, "w", encoding='utf-8') as index_file:
-            writer = csv.writer(index_file)
-            self._add_to_index(writer)
-
-    def _add_to_index(self, writer) -> None:
-        """add songs and sub-directories to the CSV index"""
-        for sub_dir in self.subdirectories:
-            sub_dir._add_to_index(writer)
-        for song in self.songs:
-            try:
-                writer.writerow([self.title, song.artist, song.title, song.filename])
-            except UnicodeEncodeError:
-                pass
 
     def __len__(self):
         return len(self.songs) + len(self.subdirectories)

--- a/musicbingo/gui/app.py
+++ b/musicbingo/gui/app.py
@@ -412,7 +412,7 @@ class MainApp(ActionPanelCallbacks):
         """
         dlg = SettingsDialog(
             self.root, self.options,
-            exclude={'create_index', 'create_superuser', 'game_id',
+            exclude={'create_superuser', 'game_id',
                      'max_tickets_per_user'})
         if dlg.result is None:
             return
@@ -609,8 +609,6 @@ class MainApp(ActionPanelCallbacks):
         """adds every available song to the "available songs" Tk Treeview"""
         name = self.options.clips().name
         self.available_songs_panel.set_title(f"Available Songs: {name}")
-        if self.options.create_index:
-            self.clips.create_index("song_index.csv")
         self.available_songs_panel.add_directory(self.clips)
         for song in self.selected_songs_panel.all_songs():
             try:

--- a/musicbingo/models/templates/clips_index.css
+++ b/musicbingo/models/templates/clips_index.css
@@ -1,0 +1,59 @@
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
+  margin: 3em 2em;
+}
+.content {
+  border: 1px solid #ddd;
+  border-radius: 0.3em;
+}
+.table {
+  background-color: #fefcfc;
+  border-collapse: collapse;
+  border-color: #dee;
+  caption-side: bottom;
+  margin-bottom: 1rem;
+  table-layout: fixed;
+  vertical-align: top;
+}
+.table > caption {
+    color: #55a;
+    font-size: 0.9rem;
+    padding-right: 1rem;
+    padding-top: 1rem;
+    text-align: right;
+}
+.table > thead {
+  color: #33c;
+  font-size: 1.5rem;
+}
+.table-striped > tbody td {
+  padding: 0.3em;
+}
+.table-striped > tbody > tr:nth-of-type(2n + 1) > td {
+  background-color: #eee;
+}
+.directory {
+  width: 18em;
+}
+.artist {
+  width: 16em;
+}
+.title {
+  width: 20em;
+}
+.filename {
+  max-width: 20rem;
+  overflow: hidden;
+  text-wrap: nowrap;
+  width: 15rem;
+}
+td.filename {
+  font-size: 0.9rem;
+  font-stretch: condensed;
+}
+@media screen and (max-width: 1200px) {
+  .filename {
+    display: none;
+  }
+}

--- a/musicbingo/models/templates/clips_index.html
+++ b/musicbingo/models/templates/clips_index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>{{ title }}</title>
+<style>
+{%- include "clips_index.css" %}
+</style>
+</head>
+<body>
+  <h1>{{ title }}</h1>
+  <div class="content">
+   <table class="table table-striped">
+   <caption>{{rows | length }} clips, generated on {{ now }}</caption>
+    <thead>
+      <tr>
+        <th class="directory">Directory</th>
+        <th class="artist">Artist</th>
+        <th class="title">Title</th>
+        <th class="filename">Filename</th>
+      </tr>
+    </thead>
+    <tbody>
+{% for row in rows %}
+    <tr>
+        <td class="directory">{{row.directory__title}}</th>
+        <td class="artist">{{row.artist}}</th>
+        <td class="title">{{row.title}}</th>
+        <td class="filename">{{row.filename}}</th>
+      </tr>
+{% endfor %}
+    </tbody>
+  </table>
+ </div>
+</body>
+</html>

--- a/musicbingo/options/options.py
+++ b/musicbingo/options/options.py
@@ -51,7 +51,6 @@ class Options(argparse.Namespace):
                     True, None, None, None),
         OptionField('mode', EnumWrapper[GameMode](GameMode), 'GUI mode',
                     GameMode.BINGO, None, None, GameMode.names()),
-        OptionField('create_index', bool, 'Create a song index file?', False, None, None, None),
         OptionField('sort_order', EnumWrapper[PageSortOrder](PageSortOrder),
                     'How to Sort tickets on generated pages',
                     PageSortOrder.INTERLEAVE.value, None, None, PageSortOrder.names()),
@@ -96,7 +95,6 @@ class Options(argparse.Namespace):
                  number_of_cards: int = 24,
                  include_artist: bool = True,
                  mode: GameMode = GameMode.BINGO,
-                 create_index: bool = False,
                  sort_order: PageSortOrder = PageSortOrder.INTERLEAVE,
                  page_order: Optional[bool] = None,
                  columns: int = 5,
@@ -135,7 +133,6 @@ class Options(argparse.Namespace):
         self.number_of_cards = number_of_cards
         self.include_artist = include_artist
         self.mode = mode
-        self.create_index = create_index
         self.sort_order = sort_order
         if page_order is not None:
             if page_order is True:

--- a/musicbingo/tests/fixtures/exported-tv-themes-v2.json
+++ b/musicbingo/tests/fixtures/exported-tv-themes-v2.json
@@ -10,7 +10,6 @@
   "colour_scheme": "blue",
   "number_of_cards": 24,
   "include_artist": true,
-  "create_index": false,
   "sort_order": "interleave",
   "page_size": "a4",
   "columns": 5,

--- a/musicbingo/tests/fixtures/exported-tv-themes-v6.json
+++ b/musicbingo/tests/fixtures/exported-tv-themes-v6.json
@@ -10,7 +10,6 @@
   "colour_scheme": "blue",
   "number_of_cards": 24,
   "include_artist": true,
-  "create_index": false,
   "sort_order": "interleave",
   "page_size": "a4",
   "columns": 5,

--- a/musicbingo/tests/test_options.py
+++ b/musicbingo/tests/test_options.py
@@ -134,13 +134,12 @@ class TestOptions(TestCaseMixin, unittest.TestCase):
             'max_tickets_per_user': 1,
             'debug': True,
             'create_superuser': False,
-            'create_index': False,
             'secret_key': None,
             'mode': GameMode.BINGO,
         }
         args = ['--bingo']
         for key, value in expected.items():
-            if key in {'clip_directory', 'create_index', 'mode', 'secret_key'}:
+            if key in {'clip_directory', 'mode', 'secret_key'}:
                 continue
             try:
                 param = name_map[key]


### PR DESCRIPTION
The `--index` option was used to generate an index file using the GUI. This option had several limitations:

* having a fixed filename
* needing the GUI to be started to generate the index

This PR replaces the removed `--index` option with a database management command that generates an index of clips. It has advantages over the old version:

* no fixed name
* supports both CSV and HTML output formats
